### PR TITLE
Allow the context to be specified in the xml configuration

### DIFF
--- a/src/SerilogTraceListener/SerilogTraceListener.cs
+++ b/src/SerilogTraceListener/SerilogTraceListener.cs
@@ -57,6 +57,18 @@ namespace SerilogTraceListener
             this.logger = logger.ForContext<SerilogTraceListener>();
         }
 
+        /// <summary>
+        ///     Creates a SerilogTraceListener for the context specified.
+        ///     <listeners>
+        ///         <add name="Serilog" type="SerilogTraceListener.SerilogTraceListener, SerilogTraceListener" initializeData="MyContext" />
+        ///     </listeners>
+
+        /// </summary>
+        public SerilogTraceListener(string context)
+        {
+            this.logger = Log.Logger.ForContext("SourceContext", context);
+        }
+
         public override bool IsThreadSafe
         {
             get { return true; }

--- a/src/SerilogTraceListener/SerilogTraceListener.csproj
+++ b/src/SerilogTraceListener/SerilogTraceListener.csproj
@@ -43,11 +43,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SerilogTraceListener/packages.config
+++ b/src/SerilogTraceListener/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.5.7" targetFramework="net45" />
+  <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>

--- a/test/SerilogTraceListener.Tests/SerilogTraceListener.Tests.csproj
+++ b/test/SerilogTraceListener.Tests/SerilogTraceListener.Tests.csproj
@@ -41,12 +41,12 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Tests.Support">
       <HintPath>..\..\packages\Serilog.Tests.Support.1.0.6\lib\net45\Serilog.Tests.Support.dll</HintPath>

--- a/test/SerilogTraceListener.Tests/packages.config
+++ b/test/SerilogTraceListener.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Serilog" version="1.5.7" targetFramework="net45" />
+  <package id="Serilog" version="1.5.14" targetFramework="net45" />
   <package id="Serilog.Tests.Support" version="1.0.6" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The initializeData parameter in the XML sends a string to the trace listener constructor.
```
  <system.diagnostics>
    <trace autoflush="true">
      <listeners>
        <add name="Serilog" type="SerilogTraceListener.SerilogTraceListener, SerilogTraceListener" initializeData="My.Awesome.Context" />
      </listeners>
    </trace>
  </system.diagnostics>
```