### PR TITLE
Fix the NuGet dependency on Serilog.

### DIFF
--- a/src/SerilogTraceListener/SerilogTraceListener.nuspec
+++ b/src/SerilogTraceListener/SerilogTraceListener.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-community-nuget.png</iconUrl>
     <tags>serilog logging diagnostics tracing TraceListener</tags>
     <dependencies>
-      <dependency id="Serilog" version="$version$" />
+      <dependency id="Serilog" version="[2.0,)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
It now requires >= 2.0.0, while previously, it required >= $Version$, which was >= 2.0.22.

When attempting to install, this was the error message:
Unable to resolve dependencies. 'Serilog 2.0.0' is not compatible with 'SerilogTraceListener 2.0.22 constraint: Serilog (>= 2.0.22)