### PR TITLE
Remove hard coded formats for trace messages

### DIFF
--- a/assets/CommonAssemblyInfo.cs
+++ b/assets/CommonAssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
-[assembly: AssemblyInformationalVersion("2.1.0")]
+// These "special" version numbers are found and replaced at build time.
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.1.1.1")]
+[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/assets/CommonAssemblyInfo.cs
+++ b/assets/CommonAssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.1.1.1")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyInformationalVersion("1.2.0")]

--- a/assets/CommonAssemblyInfo.cs
+++ b/assets/CommonAssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
-[assembly: AssemblyInformationalVersion("1.2.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.0")]

--- a/src/SerilogTraceListener/Core/Pipeline/SilentLogger.cs
+++ b/src/SerilogTraceListener/Core/Pipeline/SilentLogger.cs
@@ -370,15 +370,15 @@ namespace Serilog.Core.Pipeline
             out MessageTemplate parsedTemplate,
             out IEnumerable<LogEventProperty> boundProperties)
         {
-            parsedTemplate = new MessageTemplate(string.Empty, new List<MessageTemplateToken>());
-            boundProperties = new List<LogEventProperty>();
+            parsedTemplate = null;
+            boundProperties = null;
             return false;
         }
 
         public bool BindProperty(string propertyName, object value, bool destructureObjects,
             out LogEventProperty property)
         {
-            property = new LogEventProperty(propertyName, new ScalarValue(string.Empty));
+            property = null;
             return false;
         }
     }

--- a/src/SerilogTraceListener/Core/Pipeline/SilentLogger.cs
+++ b/src/SerilogTraceListener/Core/Pipeline/SilentLogger.cs
@@ -378,7 +378,7 @@ namespace Serilog.Core.Pipeline
         public bool BindProperty(string propertyName, object value, bool destructureObjects,
             out LogEventProperty property)
         {
-            property = new LogEventProperty(string.Empty, new ScalarValue(string.Empty));
+            property = new LogEventProperty(propertyName, new ScalarValue(string.Empty));
             return false;
         }
     }

--- a/test/SerilogTraceListener.Tests/SerilogTraceListener.Tests.csproj
+++ b/test/SerilogTraceListener.Tests/SerilogTraceListener.Tests.csproj
@@ -44,16 +44,16 @@
       <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.Tests.Support, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Tests.Support.1.0.9\lib\net45\Serilog.Tests.Support.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SerilogTraceListenerSeverityConversionTests.cs" />
     <Compile Include="SerilogTraceListenerTests.cs" />
+    <Compile Include="Support\DelegatingSink.cs" />
+    <Compile Include="Support\Extensions.cs" />
+    <Compile Include="Support\LogEventAssert.cs" />
+    <Compile Include="Support\Some.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -65,6 +65,9 @@
       <Project>{956ED9D7-DC59-4A46-AC32-A255AEAD383B}</Project>
       <Name>SerilogTraceListener</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/SerilogTraceListener.Tests/Support/DelegatingSink.cs
+++ b/test/SerilogTraceListener.Tests/Support/DelegatingSink.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    public class DelegatingSink : ILogEventSink
+    {
+        readonly Action<LogEvent> _write;
+
+        public DelegatingSink(Action<LogEvent> write)
+        {
+            if (write == null) throw new ArgumentNullException("write");
+            _write = write;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            _write(logEvent);
+        }
+
+        public static LogEvent GetLogEvent(Action<ILogger> writeAction)
+        {
+            LogEvent result = null;
+            var l = new LoggerConfiguration()
+                .WriteTo.Sink(new DelegatingSink(le => result = le))
+                .CreateLogger();
+
+            writeAction(l);
+            return result;
+        }
+    }
+}

--- a/test/SerilogTraceListener.Tests/Support/Extensions.cs
+++ b/test/SerilogTraceListener.Tests/Support/Extensions.cs
@@ -1,0 +1,12 @@
+﻿using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    public static class Extensions
+    {
+        public static object LiteralValue(this LogEventPropertyValue @this)
+        {
+            return ((ScalarValue)@this).Value;
+        }
+    }
+}

--- a/test/SerilogTraceListener.Tests/Support/LogEventAssert.cs
+++ b/test/SerilogTraceListener.Tests/Support/LogEventAssert.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using NUnit.Framework;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    /// <summary>
+    ///     The LogEventAssert class contains a collection of static methods that
+    ///     implement assertions againt Serilog.Events.LogEvent
+    /// </summary>
+    public static class LogEventAssert
+    {
+        public static void HasLevel(LogEventLevel level, LogEvent logEvent)
+        {
+            Assert.That(logEvent.Level, Is.EqualTo(level), "A log level different from the expected was found.");
+        }
+
+        public static void HasMessage(string message, LogEvent logEvent)
+        {
+            Assert.That(logEvent.RenderMessage(), Is.EqualTo(message), "The rendered message was not as expected.");
+        }
+
+        public static void HasProperty(string propertyName, LogEvent logEvent)
+        {
+            Assert.That(logEvent.Properties, Contains.Key(propertyName), "Exected property was not found.");
+        }
+
+        public static void DoesNotHaveProperty(string propertyName, LogEvent logEvent)
+        {
+            Assert.That(logEvent.Properties.ContainsKey(propertyName), Is.False, "Found property {0} when it should not have been found", propertyName);
+        }
+
+        public static void HasPropertyValue(object propertyValue, string propertyName, LogEvent logEvent)
+        {
+            HasProperty(propertyName, logEvent);
+
+            LogEventPropertyValue value = logEvent.Properties[propertyName];
+            Assert.That(value.LiteralValue(), Is.EqualTo(propertyValue), "The property value was not as expected");
+        }
+
+        public static void HasPropertyValueSequenceValue(object[] propertyValue, string propertyName, LogEvent logEvent)
+        {
+            HasProperty(propertyName, logEvent);
+
+            LogEventPropertyValue value = logEvent.Properties[propertyName];
+            var sequence = ((SequenceValue) value).Elements.Select(pv => pv.LiteralValue());
+
+            Assert.That(sequence, Is.EquivalentTo(propertyValue.Select(_ => _.ToString())), "The property value was not as expected");
+        }
+    }
+}

--- a/test/SerilogTraceListener.Tests/Support/Some.cs
+++ b/test/SerilogTraceListener.Tests/Support/Some.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Serilog.Tests.Support
+{
+    public static class Some
+    {
+        static int Counter;
+
+        public static int Int()
+        {
+            return Interlocked.Increment(ref Counter);
+        }
+
+        public static decimal Decimal()
+        {
+            return Int() + 0.123m;
+        }
+
+        public static string String(string tag = null)
+        {
+            return (tag ?? "") + "__" + Int();
+        }
+
+        public static Guid Guid()
+        {
+            return System.Guid.NewGuid();
+        }
+
+        public static TimeSpan TimeSpan()
+        {
+            return System.TimeSpan.FromMinutes(Int());
+        }
+
+        public static DateTime Instant()
+        {
+            return new DateTime(2012, 10, 28) + TimeSpan();
+        }
+
+        public static DateTimeOffset OffsetInstant()
+        {
+            return new DateTimeOffset(Instant());
+        }
+
+        public static LogEvent InformationEvent(DateTimeOffset? timestamp = null)
+        {
+            return new LogEvent(timestamp ?? OffsetInstant(), LogEventLevel.Information,
+                null, MessageTemplate(), Enumerable.Empty<LogEventProperty>());
+        }
+
+        public static LogEventProperty LogEventProperty()
+        {
+            return new LogEventProperty(String(), new ScalarValue(Int()));
+        }
+
+        public static string NonexistentTempFilePath()
+        {
+            return Path.Combine(Path.GetTempPath(), Guid() + ".txt");
+        }
+
+        public static string TempFilePath()
+        {
+            return Path.GetTempFileName();
+        }
+
+        public static string TempFolderPath()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid().ToString());
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        public static MessageTemplate MessageTemplate()
+        {
+            return new MessageTemplateParser().Parse(String());
+        }
+    }
+}

--- a/test/SerilogTraceListener.Tests/packages.config
+++ b/test/SerilogTraceListener.Tests/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="Serilog" version="2.0.0" targetFramework="net45" />
-  <package id="Serilog.Tests.Support" version="1.0.9" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
* The previous version of SerilogTraceListener had hard coded formats for various messages.
* This update removes the hard coded formats, so the message is just the actual message as logged.
* Additional values (source, ID, etc) are still logged as properties.
* E.g. If the developer traces (... "level={0} user={1}", 5, Thread.CurrentPrincipal.Identity.Name), then they are expecting the message to just be something like "level=5 user=Alice", not some hard coded format with several prefixed values.
* If a prefix is wanted, the developer can configure this in the sink, e.g. in the format for a file logger, as a tag in Seq, etc.
* Also, any format args are also logged as separate properties, although they don't have meaningful names so are just logged as properties "0", "1", etc.
* However, this still allows some advantages, e.g. highlighting args in a literate console, or searching on Type (hash of the message without arg values) in Seq
* It also allows some filtering in Seq, e.g. @0 > 3, or @1 == "Alice", as there is usually enough context for the numbered args to have meaning.


