### PR TITLE
Add tests and fix error with TraceData having the wrong property

### DIFF
--- a/src/SerilogTraceListener/SerilogTraceListener.cs
+++ b/src/SerilogTraceListener/SerilogTraceListener.cs
@@ -93,13 +93,13 @@ namespace SerilogTraceListener
 
         public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, object data)
         {
-            var properties = CreateTraceProperties(source, TraceEventType.Transfer, id);
+            var properties = CreateTraceProperties(source, eventType, id);
             WriteData(eventType, properties, data);
         }
 
         public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, params object[] data)
         {
-            var properties = CreateTraceProperties(source, TraceEventType.Transfer, id);
+            var properties = CreateTraceProperties(source, eventType, id);
             WriteData(eventType, properties, data);
         }
 
@@ -125,9 +125,10 @@ namespace SerilogTraceListener
 
         public override void TraceTransfer(TraceEventCache eventCache, string source, int id, string message, Guid relatedActivityId)
         {
-            var properties = CreateTraceProperties(source, TraceEventType.Transfer, id);
+            var eventType = TraceEventType.Transfer;
+            var properties = CreateTraceProperties(source, eventType, id);
             SafeAddProperty(properties, RelatedActivityIdProperty, relatedActivityId);
-            Write(TraceEventType.Transfer, null, message, properties);
+            Write(eventType, null, message, properties);
         }
 
         public override void Write(object data)

--- a/test/SerilogTraceListener.Tests/SerilogTraceListenerTests.cs
+++ b/test/SerilogTraceListener.Tests/SerilogTraceListenerTests.cs
@@ -226,6 +226,7 @@ namespace SerilogTraceListener.Tests
             LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
             LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
             LogEventAssert.HasPropertyValue(relatedActivityId, "RelatedActivityId", _loggedEvent);
+            LogEventAssert.HasPropertyValue(TraceEventType.Transfer, "TraceEventType", _loggedEvent);
         }
 
         [Test]
@@ -247,8 +248,8 @@ namespace SerilogTraceListener.Tests
             LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
             LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
             LogEventAssert.HasPropertyValue(data.ToString(), "TraceData", _loggedEvent);
+            LogEventAssert.HasPropertyValue(WarningEventType, "TraceEventType", _loggedEvent);
         }
-
 
         [Test]
         public void CapturesTraceDataArrayOfInt()
@@ -307,6 +308,7 @@ namespace SerilogTraceListener.Tests
                 data2,
                 data3
             }, "TraceData", _loggedEvent);
+            LogEventAssert.HasPropertyValue(WarningEventType, "TraceEventType", _loggedEvent);
         }
 
         [Test]


### PR DESCRIPTION
Fix cut and paste error with TraceData having the wrong event type being logged. 

Also, if you merge into master, note that the build on master is failing and failing to push new packages to nuget.org