### PR TITLE
write log in time like in parent lib (Serilog)

### DIFF
--- a/src/SerilogTraceListener/SerilogTraceListener.cs
+++ b/src/SerilogTraceListener/SerilogTraceListener.cs
@@ -246,7 +246,7 @@ namespace SerilogTraceListener
             // boundProperties will be empty and can be ignored
             if (logger.BindMessageTemplate(messageTemplate, null, out parsedTemplate, out boundProperties))
             {
-                var logEvent = new LogEvent(DateTimeOffset.UtcNow, level, exception, parsedTemplate, properties);
+                var logEvent = new LogEvent(DateTimeOffset.Now, level, exception, parsedTemplate, properties);
                 logger.Write(logEvent);
             }
         }


### PR DESCRIPTION
We found the problem. When we write logs through Serilog and write logs through SerilogTraceListener, logs are written in different time zones, which makes it difficult to read logs in systems with sorting by time.