### PR TITLE
HACK to force SerilogTraceListener to wire up Serilog after it has already been initialized via config

### DIFF
--- a/src/SerilogTraceListener/SerilogTraceListener.cs
+++ b/src/SerilogTraceListener/SerilogTraceListener.cs
@@ -41,18 +41,17 @@ namespace SerilogTraceListener
         const string MessagelessTraceEventMessageTemplate = "{TraceSource:l} {TraceEventType}: {TraceEventId}";
         const string TraceDataMessageTemplate = "{TraceData}";
         ILogger logger;
-        static SerilogTraceListener _staticLastListener;    //keep a static copy of the latest SerilogTraceListener, for rewiring the Log.Logger if you use diagnostics config to create your SerilogTraceListener
 
         /// <summary>
-        ///     Creates a SerilogTraceListener that uses the logger from `Serilog.Log`
+        ///     Creates a SerilogTraceListener that sets logger to null so we can still use Serilog's Logger.Log
         /// </summary>
         /// <remarks>
         ///     This is needed because TraceListeners are often configured through XML
         ///     where there would be no opportunity for constructor injection
         /// </remarks>
-        public SerilogTraceListener() : this(Log.Logger)
+        public SerilogTraceListener()
         {
-            _staticLastListener = this; //keep a copy of the most recently constructed SerilogTraceListener in case we need to rewire the logger after TraceListners are wired BEFORE the Log.Logger was created
+            logger = null;
         }
 
         /// <summary>
@@ -61,7 +60,6 @@ namespace SerilogTraceListener
         public SerilogTraceListener(ILogger logger)
         {
             this.logger = logger.ForContext<SerilogTraceListener>();
-            //NOTE: if we could compare the ILogger passed in to "SilentLogger" then this would be a much better solution, but alas, Serilog made that class private for...reasons?
         }
 
         /// <summary>
@@ -250,7 +248,8 @@ namespace SerilogTraceListener
         private void SafeAddProperty(IList<LogEventProperty> properties, string name, object value)
         {
             LogEventProperty property;
-            if (logger.BindProperty(name, value, false, out property))
+            var localLogger = logger ?? Log.Logger;
+            if (localLogger.BindProperty(name, value, false, out property))
             {
                 properties.Add(property);
             }
@@ -271,11 +270,13 @@ namespace SerilogTraceListener
             }
             MessageTemplate parsedTemplate;
             IEnumerable<LogEventProperty> boundProperties;
+
+            var localLogger = logger ?? Log.Logger;
             // boundProperties will be empty and can be ignored
-            if (logger.BindMessageTemplate(messageTemplate, null, out parsedTemplate, out boundProperties))
+            if (localLogger.BindMessageTemplate(messageTemplate, null, out parsedTemplate, out boundProperties))
             {
                 var logEvent = new LogEvent(DateTimeOffset.Now, level, exception, parsedTemplate, properties);
-                logger.Write(logEvent);
+                localLogger.Write(logEvent);
             }
         }
 
@@ -320,17 +321,6 @@ namespace SerilogTraceListener
                         return LogEventLevel.Debug;
                     }
             }
-        }
-
-        /// <summary>HACK to get SerilogTraceListener wired up to a real Serilog if you set it up in diagnostics config<summary>
-        /// <param name="newSerilogger">pass in the ILogger that you setup after the config built our SerilogTraceListener for us</param>
-        public static void ConnectSerilog(ILogger newSerilogger)
-        {
-            //I'm not sure this really matters much, but it does offer some kind of "what do you *think* you are doing" kind of protection
-            if (_staticLastListener == null)
-                throw new InvalidOperationException($"Do not try to re-connect to Serilog if you are not using diagnostics config to setup your SerilogTraceListener");
-            //would be better if we could compare to SilentLogger (back in the constructor) but its protected by Serilog
-            _staticLastListener.logger = newSerilogger;
         }
     }
 }

--- a/test/SerilogTraceListener.Tests/SerilogTraceListenerTests.cs
+++ b/test/SerilogTraceListener.Tests/SerilogTraceListenerTests.cs
@@ -5,6 +5,7 @@ using Serilog.Tests.Support;
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 
 namespace SerilogTraceListener.Tests
 {
@@ -26,15 +27,17 @@ namespace SerilogTraceListener.Tests
 
         global::SerilogTraceListener.SerilogTraceListener _traceListener;
         LogEvent _loggedEvent;
+        LogEvent _loggedEvent2;
+        ILogger _logger;
 
         [SetUp]
         public void SetUp()
         {
             var delegatingSink = new DelegatingSink(evt => { _loggedEvent = evt; });
-            var logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Sink(delegatingSink).CreateLogger();
+            _logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Sink(delegatingSink).CreateLogger();
 
             _loggedEvent = null;
-            _traceListener = new global::SerilogTraceListener.SerilogTraceListener(logger);
+            _traceListener = new global::SerilogTraceListener.SerilogTraceListener(_logger);
         }
 
         [TearDown]
@@ -401,6 +404,40 @@ namespace SerilogTraceListener.Tests
 
             _traceListener.TraceData(new TraceEventCache(), _source, TraceEventType.Information, 4, _message);
             Assert.NotNull(_loggedEvent);
+        }
+
+        [Test]
+        public void DontTryToRewireSerilogTraceListenerIfYouArentUsingDiagnosticsConfig()
+        {
+            //use reflection to RESET the static SerilogTraceListener._staticLastListener to NULL in case the test "CanConfigureAfterTraceListenerIsWired" has already been run
+            var field = typeof(SerilogTraceListener).GetField("_staticLastListener", BindingFlags.Static | BindingFlags.NonPublic);
+            field.SetValue(null, null);
+
+            //confirm SerilogTraceListener throws if you never called the SerilogTraceListener empty constructor
+            var newLogger = new LoggerConfiguration().MinimumLevel.Verbose().CreateLogger();
+
+            Assert.Throws<InvalidOperationException>(() => SerilogTraceListener.ConnectSerilog(newLogger));
+        }
+
+        [Test]
+        public void CanConfigureAfterTraceListenerIsWired()
+        {
+            _loggedEvent2 = null;
+            var delegatingSink2 = new DelegatingSink(evt => { _loggedEvent2 = evt; });
+
+            var newLogger = new LoggerConfiguration().MinimumLevel.Verbose().CreateLogger();
+
+            //NOTE: not quite the same as if the SerilogTraceListener was created by the CLR via diagnostics config, but its something...
+            SerilogTraceListener fakedSerilogTraceListener = new SerilogTraceListener();
+
+            SerilogTraceListener.ConnectSerilog(newLogger);
+            _traceListener.TraceData(new TraceEventCache(), _source, TraceEventType.Information, 3, _message);
+            Assert.Null(_loggedEvent2);
+
+            _loggedEvent = null;
+            SerilogTraceListener.ConnectSerilog(_logger);
+            _traceListener.TraceData(new TraceEventCache(), _source, TraceEventType.Information, 4, _message);
+            Assert.NotNull(_loggedEvent);   //this test isn't quite right....
         }
 
         private class DummyFilter: TraceFilter


### PR DESCRIPTION
This is a HACK, but it works well enough.
Also added notes to the readme.md about a different way to get SerilogTraceListener to work if the Serilog.Log was created AFTER the TraceListener was wired to the TraceSources (presumably via config)
See Issue #24 